### PR TITLE
Error handling at front end

### DIFF
--- a/is215project.client/src/app/app.component.ts
+++ b/is215project.client/src/app/app.component.ts
@@ -62,7 +62,11 @@ export class AppComponent {
         }
 
         if (!n) {
-          this.snack.open("Cannot generate content!", "Close", { duration: 10000 });
+          this.spinner.hide();
+          const snackBarRef = this.snack.open("Cannot generate content! Please upload a different photo.", "Close", { duration: 10000 });
+          snackBarRef.afterDismissed().subscribe(() => {
+            window.location.reload();
+          });
         }
 
         this.spinner.hide();
@@ -70,7 +74,10 @@ export class AppComponent {
 
       , error: (e) => {
         this.spinner.hide();
-        this.snack.open("Cannot upload image to S3!", "Close", { duration: 10000 });
+        const snackBarRef = this.snack.open("Cannot upload image to S3! Try again!", "Close", { duration: 10000 });
+        snackBarRef.afterDismissed().subscribe(() => {
+          window.location.reload();
+        });
       }
 
     });


### PR DESCRIPTION
When s3 cannot upload data or the image cannot generate a content, snack bar appears and will reload the page after user clicks Close.